### PR TITLE
Fix local var type returns null

### DIFF
--- a/src/main/java/decaf/frontend/typecheck/Namer.java
+++ b/src/main/java/decaf/frontend/typecheck/Namer.java
@@ -284,6 +284,7 @@ public class Namer extends Phase<Tree.TopLevel, Tree.TopLevel> implements TypeLi
         var earlier = ctx.findConflict(def.name);
         if (earlier.isPresent()) {
             issue(new DeclConflictError(def.pos, def.name, earlier.get().pos));
+            def.typeLit.type = BuiltInType.ERROR;
             return;
         }
 


### PR DESCRIPTION
When a `DeclConflictError` occurs in `Namer.visitLocalVarDef`, `def.typeLit.type` is still null, which may further lead to the null pointer exception.

Test program:
```
class Foo {
    void foo(int a, int b, int c) {}
}

class Bar extends Foo {
    void foo(int a, int b, int b) {} // DeclConflictError in LocalVarDef
}
class Main {
    static void main() {}
}
```