### PR TITLE
Issue an error when overriding methods in the same class

### DIFF
--- a/src/main/java/decaf/frontend/typecheck/Namer.java
+++ b/src/main/java/decaf/frontend/typecheck/Namer.java
@@ -217,7 +217,7 @@ public class Namer extends Phase<Tree.TopLevel, Tree.TopLevel> implements TypeLi
         if (earlier.isPresent()) {
             if (earlier.get().isMethodSymbol()) { // may be overriden
                 var suspect = (MethodSymbol) earlier.get();
-                if (!suspect.isStatic() && !method.isStatic()) {
+                if (suspect.domain() != ctx.currentScope() && !suspect.isStatic() && !method.isStatic()) {
                     // Only non-static methods can be overriden, but the type signature must be equivalent.
                     var formal = new FormalScope();
                     typeMethod(method, ctx, formal);


### PR DESCRIPTION
Test program:
```
class Foo {
    void foo() {
        Print("1");
    }
    void foo() {
        Print("2");
    }
}

class Main {
    static void main() {
        class Foo f = new Foo();
        f.foo();
    }
}
```