### PR TITLE
Fix ClassCastException when VarSel receiver type is error

### DIFF
--- a/src/main/java/decaf/frontend/typecheck/Typer.java
+++ b/src/main/java/decaf/frontend/typecheck/Typer.java
@@ -367,7 +367,11 @@ public class Typer extends Phase<Tree.TopLevel, Tree.TopLevel> implements TypeLi
             }
         }
 
-        if (rt.noError() && !rt.isClassType()) {
+        if (!rt.noError()) {
+            return;
+        }
+
+        if (!rt.isClassType()) {
             issue(new NotClassFieldError(expr.pos, expr.name, rt.toString()));
             return;
         }


### PR DESCRIPTION
Test case:
```
class Main {
    static void main() {
        foo().bar;
    }
}
```