### PR TITLE
refine block return check; return does not necessarily occur at the end

### DIFF
--- a/src/main/java/decaf/frontend/typecheck/Typer.java
+++ b/src/main/java/decaf/frontend/typecheck/Typer.java
@@ -84,7 +84,9 @@ public class Typer extends Phase<Tree.TopLevel, Tree.TopLevel> implements TypeLi
             stmt.accept(this, ctx);
         }
         ctx.close();
-        block.returns = !block.stmts.isEmpty() && block.stmts.get(block.stmts.size() - 1).returns;
+        /* if any statement in the block always returns, then we know this block will eventually
+         * return (if it doesn't loop forever), since statements are executed sequentially */
+        block.returns = block.stmts.stream().anyMatch(s -> s.returns);
     }
 
     @Override


### PR DESCRIPTION
Consider the following program:

```
class Main {
  static void main() {
  }

  int foo() {
    return 10;
    int a = 1;
  }
}
```
It gives this error
```
*** Error at (5,13): missing return statement: control reaches end of non-void block
```

This is because our typer for method only checks whether the last statement in a block returns. In this case ```int a = 1``` doesn't.

Although ```int a = 1``` is unreachable, the function is syntactically correct, and semantically meaningful (always returns). Thus it should pass the type checker. 

We could potentially issue a warning about the unreachable statement(s), but that's another story.