### PR TITLE
Prohibit class name to be used as actual object instance

### DIFF
--- a/src/main/java/decaf/frontend/typecheck/Typer.java
+++ b/src/main/java/decaf/frontend/typecheck/Typer.java
@@ -352,7 +352,8 @@ public class Typer extends Phase<Tree.TopLevel, Tree.TopLevel> implements TypeLi
 
         // has receiver
         var receiver = expr.receiver.get();
-        allowClassNameVar = true;
+        /* allow class name as VarSel receiver only in chained VerSel structures */
+        allowClassNameVar = (receiver instanceof Tree.VarSel);
         receiver.accept(this, ctx);
         allowClassNameVar = false;
         var rt = receiver.type;
@@ -422,7 +423,8 @@ public class Typer extends Phase<Tree.TopLevel, Tree.TopLevel> implements TypeLi
 
         if (expr.receiver.isPresent()) {
             var receiver = expr.receiver.get();
-            allowClassNameVar = true;
+            /* allow class name as VarSel receiver only in chained VerSel structures */
+            allowClassNameVar = (receiver instanceof Tree.VarSel);
             receiver.accept(this, ctx);
             allowClassNameVar = false;
             rt = receiver.type;

--- a/src/main/java/decaf/frontend/typecheck/Typer.java
+++ b/src/main/java/decaf/frontend/typecheck/Typer.java
@@ -352,7 +352,7 @@ public class Typer extends Phase<Tree.TopLevel, Tree.TopLevel> implements TypeLi
 
         // has receiver
         var receiver = expr.receiver.get();
-        /* allow class name as VarSel receiver only in chained VerSel structures */
+        // allow class name as VarSel receiver only in chained VerSel structures
         allowClassNameVar = (receiver instanceof Tree.VarSel);
         receiver.accept(this, ctx);
         allowClassNameVar = false;
@@ -423,7 +423,7 @@ public class Typer extends Phase<Tree.TopLevel, Tree.TopLevel> implements TypeLi
 
         if (expr.receiver.isPresent()) {
             var receiver = expr.receiver.get();
-            /* allow class name as VarSel receiver only in chained VerSel structures */
+            // allow class name as VarSel receiver only in chained VerSel structures
             allowClassNameVar = (receiver instanceof Tree.VarSel);
             receiver.accept(this, ctx);
             allowClassNameVar = false;


### PR DESCRIPTION
Consider this program.
```
class Main {
  int a;

  static void main() {
    foo(Main).main();
    foo(Main).a;
  }

  static class Main foo(class Main object) {
    return object;
  }
}
```

Class name ```Main``` is used as object instance and passed as argument to method ```foo```.

Expected output from type-check phases:
```
*** Error at (5,9): undeclared variable 'Main'
*** Error at (6,9): undeclared variable 'Main'
```
Actual output:
```
GLOBAL SCOPE:
    (1,1) -> class Main
    CLASS SCOPE OF 'Main':
        (2,7) -> variable a : int
        (4,15) -> STATIC function main : () => void
        (9,21) -> STATIC function foo : class Main => class Main
        FORMAL SCOPE OF 'main':
            <empty>
            LOCAL SCOPE:
                <empty>
        FORMAL SCOPE OF 'foo':
            (9,36) -> variable @object : class Main
            LOCAL SCOPE:
                <empty>
```